### PR TITLE
132 implement naming changes [BREAKING]

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -17,7 +17,7 @@ type Pool @entity {
   metadata: String!
 
   minEpochTime: Int!
-  maxNavAge: Int!
+  maxPortfolioValuationAge: Int!
 
   # This cannot reference Pool directly, since this leads to a cyclic dependency.
   currentEpoch: Int!
@@ -25,27 +25,27 @@ type Pool @entity {
   lastEpochExecuted: Int
 
   #States
-  netAssetValue: BigInt!
+  portfolioValuation: BigInt!
   totalReserve: BigInt!
   availableReserve: BigInt!
   maxReserve: BigInt!
-  totalDebt: BigInt!
+  sumDebt: BigInt!
   value: BigInt!
 
   # Aggregated transaction data over the last period
-  totalBorrowed_: BigInt
-  totalRepaid_: BigInt
-  totalInvested_: BigInt
-  totalRedeemed_: BigInt
-  totalNumberOfLoans_: BigInt
+  sumBorrowedAmount_: BigInt
+  sumRepaidAmount_: BigInt
+  sumInvestedAmount_: BigInt
+  sumRedeemedAmount_: BigInt
+  sumNumberOfLoans_: BigInt
 
-  totalNumberOfActiveLoans: BigInt!
-  totalDebtOverdue: BigInt!
-  totalWrittenOff_: BigInt!
+  sumNumberOfActiveLoans: BigInt!
+  sumDebtOverdue: BigInt!
+  sumDebtWrittenOff_: BigInt!
 
   # Cumulated transaction data since pool creation
-  totalEverBorrowed: BigInt
-  totalEverNumberOfLoans: BigInt
+  sumBorrowedAmount: BigInt
+  sumNumberOfLoans: BigInt
 
   tranches: [Tranche] @derivedFrom(field: "pool")
 }
@@ -60,25 +60,25 @@ type PoolSnapshot @entity {
   periodStart: Date! @index
 
   #States
-  netAssetValue: BigInt!
+  portfolioValuation: BigInt!
   totalReserve: BigInt!
   availableReserve: BigInt!
   maxReserve: BigInt!
-  totalDebt: BigInt!
+  sumDebt: BigInt!
   value: BigInt!
 
   # Aggregated transaction data over the last period
-  totalBorrowed_: BigInt
-  totalRepaid_: BigInt
-  totalInvested_: BigInt
-  totalRedeemed_: BigInt
-  totalNumberOfLoans_: BigInt
+  sumBorrowedAmount_: BigInt
+  sumRepaidAmount_: BigInt
+  sumInvestedAmount_: BigInt
+  sumRedeemedAmount_: BigInt
+  sumNumberOfLoans_: BigInt
 
-  totalNumberOfActiveLoans: BigInt!
+  sumNumberOfActiveLoans: BigInt!
 
   # Cumulated transaction data since pool creation
-  totalEverBorrowed: BigInt
-  totalEverNumberOfLoans: BigInt
+  sumBorrowedAmount: BigInt
+  sumNumberOfLoans: BigInt
 }
 
 type Tranche @entity {
@@ -94,19 +94,19 @@ type Tranche @entity {
   interestRatePerSec: BigInt
   minRiskBuffer: BigInt
 
-  active: Boolean! @index
+  isActive: Boolean! @index
 
-  supply: BigInt
-  price: BigInt
-  debt: BigInt
+  tokenSupply: BigInt
+  tokenPrice: BigInt
+  sumDebt: BigInt
 
-  outstandingInvestOrders_: BigInt!
-  outstandingRedeemOrders_: BigInt!
-  outstandingRedeemOrdersCurrency_: BigInt!
+  sumOutstandingInvestOrders_: BigInt!
+  sumOutstandingRedeemOrders_: BigInt!
+  sumOutstandingRedeemOrdersCurrency_: BigInt!
 
-  fulfilledInvestOrders_: BigInt!
-  fulfilledRedeemOrders_: BigInt!
-  fulfilledRedeemOrdersCurrency_: BigInt!
+  sumFulfilledInvestOrders_: BigInt!
+  sumFulfilledRedeemOrders_: BigInt!
+  sumFulfilledRedeemOrdersCurrency_: BigInt!
 
   yield30DaysAnnualized: BigInt
   yield90DaysAnnualized: BigInt
@@ -122,17 +122,17 @@ type TrancheSnapshot @entity {
   blockNumber: Int!
   periodStart: Date! @index
 
-  supply: BigInt
-  price: BigInt
-  debt: BigInt
+  tokenSupply: BigInt
+  tokenPrice: BigInt
+  sumDebt: BigInt
 
-  outstandingInvestOrders_: BigInt!
-  outstandingRedeemOrders_: BigInt!
-  outstandingRedeemOrdersCurrency_: BigInt!
+  sumOutstandingInvestOrders_: BigInt!
+  sumOutstandingRedeemOrders_: BigInt!
+  sumOutstandingRedeemOrdersCurrency_: BigInt!
 
-  fulfilledInvestOrders_: BigInt!
-  fulfilledRedeemOrders_: BigInt!
-  fulfilledRedeemOrdersCurrency_: BigInt!
+  sumFulfilledInvestOrders_: BigInt!
+  sumFulfilledRedeemOrders_: BigInt!
+  sumFulfilledRedeemOrdersCurrency_: BigInt!
 
   yield30DaysAnnualized: BigInt
   yield90DaysAnnualized: BigInt
@@ -151,10 +151,10 @@ type Epoch @entity {
   executedAt: Date
 
   # Aggregated data during this epoch
-  totalBorrowed: BigInt!
-  totalRepaid: BigInt!
-  totalInvested: BigInt!
-  totalRedeemed: BigInt!
+  sumBorrowedAmount: BigInt!
+  sumRepaidAmount: BigInt!
+  sumInvestedAmount: BigInt!
+  sumRedeemedAmount: BigInt!
 
   epochStates: [EpochState] @derivedFrom(field: "epoch")
 
@@ -166,17 +166,17 @@ type EpochState @entity {
   epoch: Epoch! @index
   trancheId: String!
 
-  price: BigInt
+  tokenPrice: BigInt
 
-  outstandingInvestOrders: BigInt!
-  outstandingRedeemOrders: BigInt!
-  outstandingRedeemOrdersCurrency: BigInt!
-  fulfilledInvestOrders: BigInt
-  fulfilledRedeemOrders: BigInt
-  fulfilledRedeemOrdersCurrency: BigInt
+  sumOutstandingInvestOrders: BigInt!
+  sumOutstandingRedeemOrders: BigInt!
+  sumOutstandingRedeemOrdersCurrency: BigInt!
+  sumFulfilledInvestOrders: BigInt
+  sumFulfilledRedeemOrders: BigInt
+  sumFulfilledRedeemOrdersCurrency: BigInt
 
-  investFulfillment: BigInt
-  redeemFulfillment: BigInt
+  investFulfillmentPercentage: BigInt
+  redeemFulfillmentPercentage: BigInt
 }
 
 enum InvestorTransactionType {
@@ -201,8 +201,8 @@ type OutstandingOrder @entity {
   epochNumber: Int!
   timestamp: Date!
 
-  invest: BigInt!
-  redeem: BigInt!
+  investAmount: BigInt!
+  redeemAmount: BigInt!
 }
 
 type InvestorTransaction @entity {
@@ -265,13 +265,13 @@ type TrancheBalance @entity {
   pool: Pool! @index
   tranche: Tranche! @index
 
-  investOrdered: BigInt!
-  investUncollected: BigInt!
-  investCollected: BigInt!
+  sumInvestOrderedAmount: BigInt!
+  sumInvestUncollectedAmount: BigInt!
+  sumInvestCollectedAmount: BigInt!
 
-  redeemOrdered: BigInt!
-  redeemUncollected: BigInt!
-  redeemCollected: BigInt!
+  sumRedeemOrderedAmount: BigInt!
+  sumRedeemUncollectedAmount: BigInt!
+  sumRedeemCollectedAmount: BigInt!
 }
 
 type CurrencyBalance @entity {
@@ -315,17 +315,17 @@ type Loan @entity {
 
   interestRatePerSec: BigInt
 
-  adminWrittenOff: Boolean
+  isAdminWrittenOff: Boolean
 
   pool: Pool!
 
-  active: Boolean! @index
+  isActive: Boolean! @index
   status: LoanStatus!
 
   outstandingDebt: BigInt
 
-  totalBorrowed_: BigInt
-  totalRepaid_: BigInt
+  borrowedAmount_: BigInt
+  repaidAmount_: BigInt
 
   writeOffIndex: Int
   writtenOffPercentage_: BigInt
@@ -343,8 +343,8 @@ type LoanSnapshot @entity {
 
   outstandingDebt: BigInt
 
-  totalBorrowed_: BigInt
-  totalRepaid_: BigInt
+  borrowedAmount_: BigInt
+  repaidAmount_: BigInt
 
   writeOffIndex: Int
   writtenOffPercentage_: BigInt
@@ -366,7 +366,7 @@ type Proxy @entity {
   delegator: String!
   delegatee: String!
   proxyType: String
-  removed: Boolean
+  isRemoved: Boolean
   delay: Int
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -33,15 +33,15 @@ type Pool @entity {
   value: BigInt!
 
   # Aggregated transaction data over the last period
-  sumBorrowedAmount_: BigInt
-  sumRepaidAmount_: BigInt
-  sumInvestedAmount_: BigInt
-  sumRedeemedAmount_: BigInt
-  sumNumberOfLoans_: BigInt
+  sumBorrowedAmount_R: BigInt
+  sumRepaidAmount_R: BigInt
+  sumInvestedAmount_R: BigInt
+  sumRedeemedAmount_R: BigInt
+  sumNumberOfLoans_R: BigInt
 
   sumNumberOfActiveLoans: BigInt!
   sumDebtOverdue: BigInt!
-  sumDebtWrittenOff_: BigInt!
+  sumDebtWrittenOff_R: BigInt!
 
   # Cumulated transaction data since pool creation
   sumBorrowedAmount: BigInt
@@ -68,11 +68,11 @@ type PoolSnapshot @entity {
   value: BigInt!
 
   # Aggregated transaction data over the last period
-  sumBorrowedAmount_: BigInt
-  sumRepaidAmount_: BigInt
-  sumInvestedAmount_: BigInt
-  sumRedeemedAmount_: BigInt
-  sumNumberOfLoans_: BigInt
+  sumBorrowedAmount_R: BigInt
+  sumRepaidAmount_R: BigInt
+  sumInvestedAmount_R: BigInt
+  sumRedeemedAmount_R: BigInt
+  sumNumberOfLoans_R: BigInt
 
   sumNumberOfActiveLoans: BigInt!
 
@@ -100,13 +100,13 @@ type Tranche @entity {
   tokenPrice: BigInt
   sumDebt: BigInt
 
-  sumOutstandingInvestOrders_: BigInt!
-  sumOutstandingRedeemOrders_: BigInt!
-  sumOutstandingRedeemOrdersCurrency_: BigInt!
+  sumOutstandingInvestOrders_R: BigInt!
+  sumOutstandingRedeemOrders_R: BigInt!
+  sumOutstandingRedeemOrdersCurrency_R: BigInt!
 
-  sumFulfilledInvestOrders_: BigInt!
-  sumFulfilledRedeemOrders_: BigInt!
-  sumFulfilledRedeemOrdersCurrency_: BigInt!
+  sumFulfilledInvestOrders_R: BigInt!
+  sumFulfilledRedeemOrders_R: BigInt!
+  sumFulfilledRedeemOrdersCurrency_R: BigInt!
 
   yield30DaysAnnualized: BigInt
   yield90DaysAnnualized: BigInt
@@ -126,13 +126,13 @@ type TrancheSnapshot @entity {
   tokenPrice: BigInt
   sumDebt: BigInt
 
-  sumOutstandingInvestOrders_: BigInt!
-  sumOutstandingRedeemOrders_: BigInt!
-  sumOutstandingRedeemOrdersCurrency_: BigInt!
+  sumOutstandingInvestOrders_R: BigInt!
+  sumOutstandingRedeemOrders_R: BigInt!
+  sumOutstandingRedeemOrdersCurrency_R: BigInt!
 
-  sumFulfilledInvestOrders_: BigInt!
-  sumFulfilledRedeemOrders_: BigInt!
-  sumFulfilledRedeemOrdersCurrency_: BigInt!
+  sumFulfilledInvestOrders_R: BigInt!
+  sumFulfilledRedeemOrders_R: BigInt!
+  sumFulfilledRedeemOrdersCurrency_R: BigInt!
 
   yield30DaysAnnualized: BigInt
   yield90DaysAnnualized: BigInt
@@ -324,12 +324,12 @@ type Loan @entity {
 
   outstandingDebt: BigInt
 
-  borrowedAmount_: BigInt
-  repaidAmount_: BigInt
+  borrowedAmount_R: BigInt
+  repaidAmount_R: BigInt
 
   writeOffIndex: Int
-  writtenOffPercentage_: BigInt
-  writtenOffAmount_: BigInt
+  writtenOffPercentage_R: BigInt
+  writtenOffAmount_R: BigInt
   penaltyInterestRatePerSec: BigInt
 }
 
@@ -343,12 +343,12 @@ type LoanSnapshot @entity {
 
   outstandingDebt: BigInt
 
-  borrowedAmount_: BigInt
-  repaidAmount_: BigInt
+  borrowedAmount_R: BigInt
+  repaidAmount_R: BigInt
 
   writeOffIndex: Int
-  writtenOffPercentage_: BigInt
-  writtenOffAmount_: BigInt
+  writtenOffPercentage_R: BigInt
+  writtenOffAmount_R: BigInt
   penaltyInterestRatePerSec: BigInt
 }
 

--- a/src/helpers/stateSnapshot.test.ts
+++ b/src/helpers/stateSnapshot.test.ts
@@ -69,7 +69,7 @@ describe('Given a pool with non zero accumulators, ', () => {
   getByField.mockReturnValue([pool])
 
   test('when a entity is snapshotted, then the accumulators are reset to 0', async () => {
-    const accumulatorProps = Object.getOwnPropertyNames(pool).filter((prop) => prop.endsWith('_'))
+    const accumulatorProps = Object.getOwnPropertyNames(pool).filter((prop) => prop.endsWith('_R'))
     const zeroedProps = accumulatorProps.reduce((acc, currentProp) => ({ ...acc, [currentProp]: BigInt(0) }), {})
     const accumulatedProps = accumulatorProps.reduce(
       (acc, currentProp) => ({ ...acc, [currentProp]: BigInt('999999999999999999') }),

--- a/src/helpers/stateSnapshot.ts
+++ b/src/helpers/stateSnapshot.ts
@@ -5,7 +5,7 @@ import { getPeriodStart } from './timekeeperService'
 /**
  * Creates a snapshot of a generic stateModel to a snapshotModel.
  * A snapshotModel has the same fields as the originating stateModel, however a timestamp and a blockNumber are added.
- * Fields ending with an _ underscore are reset to 0 at the end of a period. All such resettable fields must be of type
+ * Fields ending with an _R underscore are reset to 0 at the end of a period. All such resettable fields must be of type
  * BigInt.
  * @param stateModel - the data model to be snapshotted
  * @param snapshotModel - the data model where the snapshot is saved. (must have additional timestamp and
@@ -38,7 +38,7 @@ async function _stateSnapshotter(
     if (fkReferenceName) snapshotEntity[fkReferenceName] = stateEntity.id
 
     const propNames = Object.getOwnPropertyNames(stateEntity)
-    const propNamesToReset = propNames.filter((propName) => propName.endsWith('_'))
+    const propNamesToReset = propNames.filter((propName) => propName.endsWith('_R'))
     for (const propName of propNamesToReset) {
       stateEntity[propName] = BigInt(0)
     }

--- a/src/mappings/handlers/investmentsHandlers.ts
+++ b/src/mappings/handlers/investmentsHandlers.ts
@@ -36,7 +36,7 @@ async function _handleInvestOrderUpdated(event: SubstrateEvent<OrderUpdatedEvent
     hash: event.extrinsic.extrinsic.hash.toString(),
     amount: newAmount.toBigInt(),
     digits: ((await CurrencyService.get(pool.currencyId)) as CurrencyService).decimals,
-    price: tranche.price,
+    price: tranche.tokenPrice,
     fee: BigInt(0),
     timestamp: event.block.timestamp,
   }
@@ -53,7 +53,7 @@ async function _handleInvestOrderUpdated(event: SubstrateEvent<OrderUpdatedEvent
 
   // Initialise or update outstanding transaction
   const oo = await OutstandingOrderService.getOrInit(orderData)
-  const oldAmount = oo.invest
+  const oldAmount = oo.investAmount
   await oo.updateInvest(orderData)
   await oo.save()
 
@@ -98,7 +98,7 @@ async function _handleRedeemOrderUpdated(event: SubstrateEvent<OrderUpdatedEvent
     hash: event.extrinsic.extrinsic.hash.toString(),
     amount: amount.toBigInt(),
     digits: digits,
-    price: tranche.price,
+    price: tranche.tokenPrice,
     fee: BigInt(0),
     timestamp: event.block.timestamp,
   }
@@ -115,7 +115,7 @@ async function _handleRedeemOrderUpdated(event: SubstrateEvent<OrderUpdatedEvent
 
   // Initialise outstanding transaction
   const oo = await OutstandingOrderService.getOrInit(orderData)
-  const oldAmount = oo.redeem
+  const oldAmount = oo.redeemAmount
   await oo.updateRedeem(orderData)
   await oo.save()
 
@@ -125,7 +125,7 @@ async function _handleRedeemOrderUpdated(event: SubstrateEvent<OrderUpdatedEvent
 
   // Update epochState outstanding total
   const epoch = await EpochService.getById(poolId.toString(), pool.currentEpoch)
-  await epoch.updateOutstandingRedeemOrders(trancheId.toHex(), orderData.amount, oldAmount, tranche.price, digits)
+  await epoch.updateOutstandingRedeemOrders(trancheId.toHex(), orderData.amount, oldAmount, tranche.tokenPrice, digits)
   await epoch.saveWithStates()
 
   // Update trancheBalance
@@ -165,7 +165,7 @@ async function _handleInvestOrdersCollected(event: SubstrateEvent<InvestOrdersCo
     hash: event.extrinsic.extrinsic.hash.toString(),
     timestamp: event.block.timestamp,
     digits: ((await CurrencyService.get(pool.currencyId)) as CurrencyService).decimals,
-    price: tranche.price,
+    price: tranche.tokenPrice,
     amount: payoutInvestmentInvest.toBigInt(),
   }
 
@@ -211,7 +211,7 @@ async function _handleRedeemOrdersCollected(event: SubstrateEvent<RedeemOrdersCo
     hash: event.extrinsic.extrinsic.hash.toString(),
     timestamp: event.block.timestamp,
     digits: ((await CurrencyService.get(pool.currencyId)) as CurrencyService).decimals,
-    price: tranche.price,
+    price: tranche.tokenPrice,
     amount: payoutInvestmentRedeem.toBigInt(),
   }
 

--- a/src/mappings/handlers/loansHandlers.ts
+++ b/src/mappings/handlers/loansHandlers.ts
@@ -71,7 +71,7 @@ async function _handleLoanBorrowed(event: SubstrateEvent<LoanBorrowedRepaidEvent
   await bt.save()
 
   // Update poolState info
-  await pool.increaseTotalBorrowings(amount.toBigInt())
+  await pool.increaseBorrowings(amount.toBigInt())
   await pool.save()
 }
 
@@ -153,7 +153,7 @@ async function _handleLoanWrittenOff(event: SubstrateEvent<LoanWrittenOffEvent>)
   const pool = await PoolService.getById(poolId.toString())
   if (pool === undefined) throw new Error('Pool not found!')
 
-  await pool.increaseTotalWrittenOff(loan.writtenOffAmount_)
+  await pool.increaseWriteOff(loan.writtenOffAmount_)
   await pool.save()
 }
 

--- a/src/mappings/handlers/loansHandlers.ts
+++ b/src/mappings/handlers/loansHandlers.ts
@@ -153,7 +153,7 @@ async function _handleLoanWrittenOff(event: SubstrateEvent<LoanWrittenOffEvent>)
   const pool = await PoolService.getById(poolId.toString())
   if (pool === undefined) throw new Error('Pool not found!')
 
-  await pool.increaseWriteOff(loan.writtenOffAmount_)
+  await pool.increaseWriteOff(loan.writtenOffAmount_R)
   await pool.save()
 }
 

--- a/src/mappings/handlers/ormlTokensHandlers.ts
+++ b/src/mappings/handlers/ormlTokensHandlers.ts
@@ -51,7 +51,7 @@ async function _handleTokenTransfer(event: SubstrateEvent<TokensTransferEvent>):
       hash: event.extrinsic.extrinsic.hash.toString(),
       timestamp: event.block.timestamp,
       digits: ((await CurrencyService.get(pool.currencyId)) as CurrencyService).decimals,
-      price: tranche.price,
+      price: tranche.tokenPrice,
       amount: amount.toBigInt(),
     }
 

--- a/src/mappings/services/investorTransactionService.test.ts
+++ b/src/mappings/services/investorTransactionService.test.ts
@@ -15,12 +15,12 @@ const orderData = <InvestorTransactionData>{
   digits: WAD_DIGITS,
   price: nToBigInt(RAY.muln(10)),
   fee: BigInt(0),
-  fulfillmentRate: BigInt('500000000000000000'),
+  fulfillmentPercentage: BigInt('500000000000000000'),
 }
 
-const executedInvestCurrency = nToBigInt(bnToBn(orderData.amount).mul(bnToBn(orderData.fulfillmentRate)).div(WAD))
+const executedInvestCurrency = nToBigInt(bnToBn(orderData.amount).mul(bnToBn(orderData.fulfillmentPercentage)).div(WAD))
 const executedInvestToken = nToBigInt(bnToBn(executedInvestCurrency).mul(RAY).div(bnToBn(orderData.price)))
-const executedRedeemToken = nToBigInt(bnToBn(orderData.amount).mul(bnToBn(orderData.fulfillmentRate)).div(WAD))
+const executedRedeemToken = nToBigInt(bnToBn(orderData.amount).mul(bnToBn(orderData.fulfillmentPercentage)).div(WAD))
 const executedRedeemCurrency = nToBigInt(bnToBn(executedRedeemToken).mul(bnToBn(orderData.price)).div(RAY))
 
 describe('Given an invest/redeem order update, when the transaction is saved,', () => {

--- a/src/mappings/services/investorTransactionService.ts
+++ b/src/mappings/services/investorTransactionService.ts
@@ -29,7 +29,7 @@ export interface InvestorTransactionData {
   readonly digits: number
   readonly price?: bigint
   readonly fee?: bigint
-  readonly fulfillmentRate?: bigint
+  readonly fulfillmentPercentage?: bigint
 }
 
 export class InvestorTransactionService extends InvestorTransaction {
@@ -56,7 +56,7 @@ export class InvestorTransactionService extends InvestorTransaction {
   static executeInvestOrder(data: InvestorTransactionData) {
     logger.info(
       `Executing invest order for address ${data.address} in pool ${data.poolId} tranche ${data.trancheId} ` +
-        `with amount: ${data.amount} fulfillmentRate: ${data.fulfillmentRate} ` +
+        `with amount: ${data.amount} fulfillmentPercentage: ${data.fulfillmentPercentage} ` +
         `price: ${data.price} digits: ${data.digits}`
     )
     const extendedData = {
@@ -70,7 +70,7 @@ export class InvestorTransactionService extends InvestorTransaction {
   static executeRedeemOrder(data: InvestorTransactionData) {
     logger.info(
       `Executing redeem order for address ${data.address} in pool ${data.poolId} tranche ${data.trancheId} ` +
-        `with amount: ${data.amount} fulfillmentRate: ${data.fulfillmentRate} ` +
+        `with amount: ${data.amount} fulfillmentPercentage: ${data.fulfillmentPercentage} ` +
         `price: ${data.price} digits: ${data.digits}`
     )
     const extendedData = {
@@ -139,6 +139,6 @@ export class InvestorTransactionService extends InvestorTransaction {
   }
 
   static computeFulfilledAmount(data: InvestorTransactionData) {
-    return nToBigInt(bnToBn(data.amount).mul(bnToBn(data.fulfillmentRate)).div(WAD))
+    return nToBigInt(bnToBn(data.amount).mul(bnToBn(data.fulfillmentPercentage)).div(WAD))
   }
 }

--- a/src/mappings/services/loanService.test.ts
+++ b/src/mappings/services/loanService.test.ts
@@ -35,7 +35,7 @@ const loan = LoanService.init(poolId, loanId, nftClassId, nftItemId, timestamp)
 
 describe('Given a new loan, when initialised', () => {
   test('then type is inactive', () => {
-    expect(loan.active).toBe(false)
+    expect(loan.isActive).toBe(false)
     expect(loan.status).toBe('CREATED')
   })
 

--- a/src/mappings/services/loanService.test.ts
+++ b/src/mappings/services/loanService.test.ts
@@ -40,7 +40,7 @@ describe('Given a new loan, when initialised', () => {
   })
 
   test('then reset accumulators are set to 0', () => {
-    const resetAccumulators = Object.getOwnPropertyNames(loan).filter((prop) => prop.endsWith('_'))
+    const resetAccumulators = Object.getOwnPropertyNames(loan).filter((prop) => prop.endsWith('_R'))
     for (const resetAccumulator of resetAccumulators) {
       expect(loan[resetAccumulator]).toBe(BigInt(0))
     }

--- a/src/mappings/services/loanService.ts
+++ b/src/mappings/services/loanService.ts
@@ -17,8 +17,8 @@ export class LoanService extends Loan {
     loan.isActive = false
     loan.status = LoanStatus.CREATED
     loan.outstandingDebt = BigInt(0)
-    loan.borrowedAmount_ = BigInt(0)
-    loan.repaidAmount_ = BigInt(0)
+    loan.borrowedAmount_R = BigInt(0)
+    loan.repaidAmount_R = BigInt(0)
 
     return loan
   }
@@ -30,12 +30,12 @@ export class LoanService extends Loan {
 
   public borrow(amount: bigint) {
     logger.info(`Increasing outstanding debt for loan ${this.id} by ${amount}`)
-    this.borrowedAmount_ += amount
+    this.borrowedAmount_R += amount
   }
 
   public repay(amount: bigint) {
     logger.info(`Decreasing outstanding debt for loan ${this.id} by ${amount}`)
-    this.repaidAmount_ += amount
+    this.repaidAmount_R += amount
   }
 
   public updateInterestRate(interestRatePerSec: bigint) {
@@ -45,11 +45,11 @@ export class LoanService extends Loan {
 
   public writeOff(percentage: bigint, penaltyInterestRatePerSec: bigint, writeOffIndex: number) {
     logger.info(`Writing off loan ${this.id} with ${percentage}`)
-    this.writtenOffPercentage_ = percentage
+    this.writtenOffPercentage_R = percentage
     this.penaltyInterestRatePerSec = penaltyInterestRatePerSec
     this.writeOffIndex = writeOffIndex
 
-    this.writtenOffAmount_ = nToBigInt(bnToBn(this.outstandingDebt).mul(bnToBn(percentage)).div(WAD))
+    this.writtenOffAmount_R = nToBigInt(bnToBn(this.outstandingDebt).mul(bnToBn(percentage)).div(WAD))
   }
 
   public updateLoanType(loanType: string, loanSpec?: AnyJson) {

--- a/src/mappings/services/loanService.ts
+++ b/src/mappings/services/loanService.ts
@@ -14,11 +14,11 @@ export class LoanService extends Loan {
     loan.poolId = poolId
     loan.collateralNftClassId = nftClassId
     loan.collateralNftItemId = nftItemId
-    loan.active = false
+    loan.isActive = false
     loan.status = LoanStatus.CREATED
     loan.outstandingDebt = BigInt(0)
-    loan.totalBorrowed_ = BigInt(0)
-    loan.totalRepaid_ = BigInt(0)
+    loan.borrowedAmount_ = BigInt(0)
+    loan.repaidAmount_ = BigInt(0)
 
     return loan
   }
@@ -30,12 +30,12 @@ export class LoanService extends Loan {
 
   public borrow(amount: bigint) {
     logger.info(`Increasing outstanding debt for loan ${this.id} by ${amount}`)
-    this.totalBorrowed_ += amount
+    this.borrowedAmount_ += amount
   }
 
   public repay(amount: bigint) {
     logger.info(`Decreasing outstanding debt for loan ${this.id} by ${amount}`)
-    this.totalRepaid_ += amount
+    this.repaidAmount_ += amount
   }
 
   public updateInterestRate(interestRatePerSec: bigint) {
@@ -65,13 +65,13 @@ export class LoanService extends Loan {
 
   public activate() {
     logger.info(`Activating loan ${this.id}`)
-    this.active = true
+    this.isActive = true
     this.status = LoanStatus.ACTIVE
   }
 
   public close() {
     logger.info(`Closing loan ${this.id}`)
-    this.active = false
+    this.isActive = false
     this.status = LoanStatus.CLOSED
   }
 

--- a/src/mappings/services/outstandingOrderService.ts
+++ b/src/mappings/services/outstandingOrderService.ts
@@ -4,7 +4,7 @@ import { OutstandingOrder } from '../../types'
 import { InvestorTransactionData } from './investorTransactionService'
 
 export class OutstandingOrderService extends OutstandingOrder {
-  static init(data: InvestorTransactionData, invest: bigint, redeem: bigint) {
+  static init(data: InvestorTransactionData, investAmount: bigint, redeemAmount: bigint) {
     const oo = new this(`${data.poolId}-${data.trancheId}-${data.address}`)
     oo.hash = data.hash
     oo.accountId = data.address
@@ -13,8 +13,8 @@ export class OutstandingOrderService extends OutstandingOrder {
     oo.epochNumber = data.epochNumber
     oo.timestamp = data.timestamp
 
-    oo.invest = invest
-    oo.redeem = redeem
+    oo.investAmount = investAmount
+    oo.redeemAmount = redeemAmount
     return oo
   }
 
@@ -43,20 +43,20 @@ export class OutstandingOrderService extends OutstandingOrder {
   }
 
   updateInvest(data: InvestorTransactionData) {
-    this.invest = data.amount
+    this.investAmount = data.amount
   }
 
   updateRedeem(data: InvestorTransactionData) {
-    this.redeem = data.amount
+    this.redeemAmount = data.amount
   }
 
-  updateUnfulfilledInvest(investFulfillment: bigint) {
-    this.invest = nToBigInt(bnToBn(this.invest).sub(bnToBn(investFulfillment)))
+  updateUnfulfilledInvest(investFulfillmentPercentage: bigint) {
+    this.investAmount = nToBigInt(bnToBn(this.investAmount).sub(bnToBn(investFulfillmentPercentage)))
     return this
   }
 
-  updateUnfulfilledRedeem(redeemFulfillment: bigint) {
-    this.redeem = nToBigInt(bnToBn(this.redeem).sub(bnToBn(redeemFulfillment)))
+  updateUnfulfilledRedeem(redeemFulfillmentPercentage: bigint) {
+    this.redeemAmount = nToBigInt(bnToBn(this.redeemAmount).sub(bnToBn(redeemFulfillmentPercentage)))
     return this
   }
 }

--- a/src/mappings/services/poolService.test.ts
+++ b/src/mappings/services/poolService.test.ts
@@ -71,7 +71,12 @@ describe('Given a new pool, when initialised', () => {
   test('when the pool data is initialised, then the correct values are fetched and set', async () => {
     await pool.initData()
     expect(api.query.poolSystem.pool).toBeCalledWith(poolId)
-    expect(pool).toMatchObject({ currencyId: 'AUSD', metadata: 'AAA', minEpochTime: 500, maxNavAge: 500 })
+    expect(pool).toMatchObject({
+      currencyId: 'AUSD',
+      metadata: 'AAA',
+      minEpochTime: 500,
+      maxPortfolioValuationAge: 500,
+    })
   })
 
   test('then it can be saved to the database', async () => {
@@ -82,9 +87,9 @@ describe('Given a new pool, when initialised', () => {
 
 describe('Given an existing pool,', () => {
   test('when the nav is updated, then the value is fetched and set correctly', async () => {
-    await pool.updateNav()
+    await pool.updatePortfolioValuation()
     expect(api.query.loans.poolNAV).toBeCalled()
-    expect(pool.netAssetValue).toBe(BigInt(100000000000000))
+    expect(pool.portfolioValuation).toBe(BigInt(100000000000000))
   })
 
   test('when the pool state is updated, then the values are fetched and set correctly', async () => {
@@ -98,12 +103,12 @@ describe('Given an existing pool,', () => {
   })
 
   test('when total borrowings are registered, then values are incremented correctly', async () => {
-    await pool.increaseTotalBorrowings(BigInt('34999000000000000'))
+    await pool.increaseBorrowings(BigInt('34999000000000000'))
     expect(pool).toMatchObject({
-      totalBorrowed_: BigInt('34999000000000000'),
-      totalEverBorrowed: BigInt('34999000000000000'),
-      totalNumberOfLoans_: BigInt(1),
-      totalEverNumberOfLoans: BigInt(1),
+      sumBorrowedAmount_: BigInt('34999000000000000'),
+      sumBorrowedAmount: BigInt('34999000000000000'),
+      sumNumberOfLoans_: BigInt(1),
+      sumNumberOfLoans: BigInt(1),
     })
   })
 

--- a/src/mappings/services/poolService.test.ts
+++ b/src/mappings/services/poolService.test.ts
@@ -62,7 +62,7 @@ describe('Given a new pool, when initialised', () => {
   })
 
   test('then reset accumulators are set to 0', () => {
-    const resetAccumulators = Object.getOwnPropertyNames(pool).filter((prop) => prop.endsWith('_'))
+    const resetAccumulators = Object.getOwnPropertyNames(pool).filter((prop) => prop.endsWith('_R'))
     for (const resetAccumulator of resetAccumulators) {
       expect(pool[resetAccumulator]).toBe(BigInt(0))
     }
@@ -105,9 +105,9 @@ describe('Given an existing pool,', () => {
   test('when total borrowings are registered, then values are incremented correctly', async () => {
     await pool.increaseBorrowings(BigInt('34999000000000000'))
     expect(pool).toMatchObject({
-      sumBorrowedAmount_: BigInt('34999000000000000'),
+      sumBorrowedAmount_R: BigInt('34999000000000000'),
       sumBorrowedAmount: BigInt('34999000000000000'),
-      sumNumberOfLoans_: BigInt(1),
+      sumNumberOfLoans_R: BigInt(1),
       sumNumberOfLoans: BigInt(1),
     })
   })

--- a/src/mappings/services/poolService.ts
+++ b/src/mappings/services/poolService.ts
@@ -16,7 +16,7 @@ export class PoolService extends Pool {
     poolId: string,
     currencyId: string,
     maxReserve: bigint,
-    maxNavAge: number,
+    maxPortfolioValuationAge: number,
     minEpochTime: number,
     timestamp: Date,
     blockNumber: number
@@ -25,26 +25,26 @@ export class PoolService extends Pool {
 
     pool.currencyId = currencyId
     pool.maxReserve = maxReserve
-    pool.maxNavAge = maxNavAge
+    pool.maxPortfolioValuationAge = maxPortfolioValuationAge
     pool.minEpochTime = minEpochTime
 
-    pool.netAssetValue = BigInt(0)
+    pool.portfolioValuation = BigInt(0)
     pool.totalReserve = BigInt(0)
     pool.availableReserve = BigInt(0)
-    pool.totalDebt = BigInt(0)
+    pool.sumDebt = BigInt(0)
     pool.value = BigInt(0)
 
-    pool.totalBorrowed_ = BigInt(0)
-    pool.totalRepaid_ = BigInt(0)
-    pool.totalInvested_ = BigInt(0)
-    pool.totalRedeemed_ = BigInt(0)
-    pool.totalNumberOfLoans_ = BigInt(0)
-    pool.totalNumberOfActiveLoans = BigInt(0)
-    pool.totalWrittenOff_ = BigInt(0)
-    pool.totalDebtOverdue = BigInt(0)
+    pool.sumBorrowedAmount_ = BigInt(0)
+    pool.sumRepaidAmount_ = BigInt(0)
+    pool.sumInvestedAmount_ = BigInt(0)
+    pool.sumRedeemedAmount_ = BigInt(0)
+    pool.sumNumberOfLoans_ = BigInt(0)
+    pool.sumNumberOfActiveLoans = BigInt(0)
+    pool.sumDebtWrittenOff_ = BigInt(0)
+    pool.sumDebtOverdue = BigInt(0)
 
-    pool.totalEverBorrowed = BigInt(0)
-    pool.totalEverNumberOfLoans = BigInt(0)
+    pool.sumBorrowedAmount = BigInt(0)
+    pool.sumNumberOfLoans = BigInt(0)
 
     //Create the pool
     const currentEpoch = 1
@@ -68,7 +68,7 @@ export class PoolService extends Pool {
     const poolData = poolReq.unwrap()
     this.metadata = metadataReq.isSome ? metadataReq.unwrap().metadata.toUtf8() : 'NA'
     this.minEpochTime = poolData.parameters.minEpochTime.toNumber()
-    this.maxNavAge = poolData.parameters.maxNavAge.toNumber()
+    this.maxPortfolioValuationAge = poolData.parameters.maxNavAge.toNumber()
     return this
   }
 
@@ -94,32 +94,32 @@ export class PoolService extends Pool {
     return this
   }
 
-  public async updateNav() {
+  public async updatePortfolioValuation() {
     const navResponse = await api.query.loans.poolNAV<Option<NavDetails>>(this.id)
     if (navResponse.isSome) {
       const navData = navResponse.unwrap()
-      this.netAssetValue = navData.latest.toBigInt()
+      this.portfolioValuation = navData.latest.toBigInt()
     }
     return this
   }
 
-  public updateTotalNumberOfActiveLoans(activeLoans: bigint) {
-    this.totalNumberOfActiveLoans = activeLoans
+  public updateNumberOfActiveLoans(numberOfActiveLoans: bigint) {
+    this.sumNumberOfActiveLoans = numberOfActiveLoans
   }
 
-  public increaseTotalBorrowings(borrowedAmount: bigint) {
-    this.totalBorrowed_ += borrowedAmount
-    this.totalEverBorrowed += borrowedAmount
-    this.totalNumberOfLoans_ += BigInt(1)
-    this.totalEverNumberOfLoans += BigInt(1)
+  public increaseBorrowings(borrowedAmount: bigint) {
+    this.sumBorrowedAmount_ += borrowedAmount
+    this.sumBorrowedAmount += borrowedAmount
+    this.sumNumberOfLoans_ += BigInt(1)
+    this.sumNumberOfLoans += BigInt(1)
   }
 
-  public increaseTotalInvested(currencyAmount: bigint) {
-    this.totalInvested_ += currencyAmount
+  public increaseInvestments(currencyAmount: bigint) {
+    this.sumInvestedAmount_ += currencyAmount
   }
 
-  public increaseTotalRedeemed(currencyAmount: bigint) {
-    this.totalRedeemed_ += currencyAmount
+  public increaseRedemptions(currencyAmount: bigint) {
+    this.sumRedeemedAmount_ += currencyAmount
   }
 
   public closeEpoch(epochId: number) {
@@ -132,21 +132,21 @@ export class PoolService extends Pool {
   }
 
   public computePoolValue() {
-    const nav = bnToBn(this.netAssetValue)
+    const nav = bnToBn(this.portfolioValuation)
     const totalReserve = bnToBn(this.totalReserve)
     this.value = nToBigInt(nav.add(totalReserve))
   }
 
-  public resetTotalDebtOverdue() {
-    this.totalDebtOverdue = BigInt(0)
+  public resetDebtOverdue() {
+    this.sumDebtOverdue = BigInt(0)
   }
 
-  public increaseTotalDebtOverdue(amount: bigint) {
-    this.totalDebtOverdue += amount
+  public increaseDebtOverdue(amount: bigint) {
+    this.sumDebtOverdue += amount
   }
 
-  public increaseTotalWrittenOff(amount: bigint) {
-    this.totalWrittenOff_ += amount
+  public increaseWriteOff(amount: bigint) {
+    this.sumDebtWrittenOff_ += amount
   }
 
   public async getTranches() {

--- a/src/mappings/services/poolService.ts
+++ b/src/mappings/services/poolService.ts
@@ -34,13 +34,13 @@ export class PoolService extends Pool {
     pool.sumDebt = BigInt(0)
     pool.value = BigInt(0)
 
-    pool.sumBorrowedAmount_ = BigInt(0)
-    pool.sumRepaidAmount_ = BigInt(0)
-    pool.sumInvestedAmount_ = BigInt(0)
-    pool.sumRedeemedAmount_ = BigInt(0)
-    pool.sumNumberOfLoans_ = BigInt(0)
+    pool.sumBorrowedAmount_R = BigInt(0)
+    pool.sumRepaidAmount_R = BigInt(0)
+    pool.sumInvestedAmount_R = BigInt(0)
+    pool.sumRedeemedAmount_R = BigInt(0)
+    pool.sumNumberOfLoans_R = BigInt(0)
     pool.sumNumberOfActiveLoans = BigInt(0)
-    pool.sumDebtWrittenOff_ = BigInt(0)
+    pool.sumDebtWrittenOff_R = BigInt(0)
     pool.sumDebtOverdue = BigInt(0)
 
     pool.sumBorrowedAmount = BigInt(0)
@@ -108,18 +108,18 @@ export class PoolService extends Pool {
   }
 
   public increaseBorrowings(borrowedAmount: bigint) {
-    this.sumBorrowedAmount_ += borrowedAmount
+    this.sumBorrowedAmount_R += borrowedAmount
     this.sumBorrowedAmount += borrowedAmount
-    this.sumNumberOfLoans_ += BigInt(1)
+    this.sumNumberOfLoans_R += BigInt(1)
     this.sumNumberOfLoans += BigInt(1)
   }
 
   public increaseInvestments(currencyAmount: bigint) {
-    this.sumInvestedAmount_ += currencyAmount
+    this.sumInvestedAmount_R += currencyAmount
   }
 
   public increaseRedemptions(currencyAmount: bigint) {
-    this.sumRedeemedAmount_ += currencyAmount
+    this.sumRedeemedAmount_R += currencyAmount
   }
 
   public closeEpoch(epochId: number) {
@@ -146,7 +146,7 @@ export class PoolService extends Pool {
   }
 
   public increaseWriteOff(amount: bigint) {
-    this.sumDebtWrittenOff_ += amount
+    this.sumDebtWrittenOff_R += amount
   }
 
   public async getTranches() {

--- a/src/mappings/services/trancheBalanceService.ts
+++ b/src/mappings/services/trancheBalanceService.ts
@@ -7,12 +7,12 @@ export class TrancheBalanceService extends TrancheBalance {
     trancheBalance.accountId = address
     trancheBalance.poolId = poolId
     trancheBalance.trancheId = `${poolId}-${trancheId}`
-    trancheBalance.investOrdered = BigInt(0)
-    trancheBalance.investUncollected = BigInt(0)
-    trancheBalance.investCollected = BigInt(0)
-    trancheBalance.redeemOrdered = BigInt(0)
-    trancheBalance.redeemUncollected = BigInt(0)
-    trancheBalance.redeemCollected = BigInt(0)
+    trancheBalance.sumInvestOrderedAmount = BigInt(0)
+    trancheBalance.sumInvestUncollectedAmount = BigInt(0)
+    trancheBalance.sumInvestCollectedAmount = BigInt(0)
+    trancheBalance.sumRedeemOrderedAmount = BigInt(0)
+    trancheBalance.sumRedeemUncollectedAmount = BigInt(0)
+    trancheBalance.sumRedeemCollectedAmount = BigInt(0)
     return trancheBalance
   }
 
@@ -31,30 +31,30 @@ export class TrancheBalanceService extends TrancheBalance {
   }
 
   public investOrder(currencyAmount: bigint) {
-    this.investOrdered += currencyAmount
+    this.sumInvestOrderedAmount += currencyAmount
   }
 
   public redeemOrder(tokenAmount: bigint) {
-    this.redeemOrdered += tokenAmount
+    this.sumRedeemOrderedAmount += tokenAmount
   }
 
   public investExecute(currencyAmount: bigint, tokenAmount: bigint) {
-    this.investOrdered -= currencyAmount
-    this.investUncollected += tokenAmount
+    this.sumInvestOrderedAmount -= currencyAmount
+    this.sumInvestUncollectedAmount += tokenAmount
   }
 
   public redeemExecute(tokenAmount: bigint, currencyAmount: bigint) {
-    this.redeemOrdered -= tokenAmount
-    this.redeemUncollected += currencyAmount
+    this.sumRedeemOrderedAmount -= tokenAmount
+    this.sumRedeemUncollectedAmount += currencyAmount
   }
 
   public investCollect(tokenAmount: bigint) {
-    this.investUncollected -= tokenAmount
-    this.investCollected += tokenAmount
+    this.sumInvestUncollectedAmount -= tokenAmount
+    this.sumInvestCollectedAmount += tokenAmount
   }
 
   public redeemCollect(currencyAmount: bigint) {
-    this.redeemUncollected -= currencyAmount
-    this.redeemCollected += currencyAmount
+    this.sumRedeemUncollectedAmount -= currencyAmount
+    this.sumRedeemCollectedAmount += currencyAmount
   }
 }

--- a/src/mappings/services/trancheService.test.ts
+++ b/src/mappings/services/trancheService.test.ts
@@ -59,7 +59,7 @@ describe('Given a new tranche, when initialised', () => {
   test('when the supply data is fetched, then the correct values are fetched and set', async () => {
     await tranches[0].updateSupply()
     expect(api.query.ormlTokens.totalIssuance).toBeCalledWith({ Tranche: [poolId, trancheIds[0]] })
-    expect(tranches[0]).toMatchObject({ supply: BigInt('9999000000000000000000') })
+    expect(tranches[0]).toMatchObject({ tokenSupply: BigInt('9999000000000000000000') })
   })
 
   test('then it can be saved to the database', async () => {
@@ -72,13 +72,13 @@ describe('Given an existing tranche,', () => {
   test('when the rpc price is updated, then the value is fetched and set correctly', async () => {
     await tranches[0].updatePriceFromRpc().catch(errorLogger)
     expect((api.rpc as ExtendedRpc).pools.trancheTokenPrices).toBeCalled()
-    expect(tranches[0].price).toBe(BigInt('2000000000000000000'))
+    expect(tranches[0].tokenPrice).toBe(BigInt('2000000000000000000'))
   })
 
   test('when a 0 rpc price is delivered, then the value is skipped and logged', async () => {
     await tranches[1].updatePriceFromRpc().catch(errorLogger)
     expect((api.rpc as ExtendedRpc).pools.trancheTokenPrices).toBeCalled()
     expect(logger.error).toBeCalled()
-    expect(tranches[1].price).toBe(BigInt('1000000000000000000000000000'))
+    expect(tranches[1].tokenPrice).toBe(BigInt('1000000000000000000000000000'))
   })
 })

--- a/src/mappings/services/trancheService.test.ts
+++ b/src/mappings/services/trancheService.test.ts
@@ -49,7 +49,7 @@ describe('Given a new tranche, when initialised', () => {
   })
 
   test('then reset accumulators are set to 0', () => {
-    const resetAccumulators = Object.getOwnPropertyNames(tranches[0]).filter((prop) => prop.endsWith('_'))
+    const resetAccumulators = Object.getOwnPropertyNames(tranches[0]).filter((prop) => prop.endsWith('_R'))
     for (const resetAccumulator of resetAccumulators) {
       expect(tranches[0][resetAccumulator]).toBe(BigInt(0))
       expect(tranches[1][resetAccumulator]).toBe(BigInt(0))

--- a/src/mappings/services/trancheService.ts
+++ b/src/mappings/services/trancheService.ts
@@ -10,12 +10,12 @@ export class TrancheService extends Tranche {
   static init(poolId: string, trancheId: string, index: number, trancheData: TrancheDetails) {
     const tranche = new this(`${poolId}-${trancheId}`)
     tranche.isActive = true
-    tranche.sumOutstandingInvestOrders_ = BigInt(0)
-    tranche.sumOutstandingRedeemOrders_ = BigInt(0)
-    tranche.sumOutstandingRedeemOrdersCurrency_ = BigInt(0)
-    tranche.sumFulfilledInvestOrders_ = BigInt(0)
-    tranche.sumFulfilledRedeemOrders_ = BigInt(0)
-    tranche.sumFulfilledRedeemOrdersCurrency_ = BigInt(0)
+    tranche.sumOutstandingInvestOrders_R = BigInt(0)
+    tranche.sumOutstandingRedeemOrders_R = BigInt(0)
+    tranche.sumOutstandingRedeemOrdersCurrency_R = BigInt(0)
+    tranche.sumFulfilledInvestOrders_R = BigInt(0)
+    tranche.sumFulfilledRedeemOrders_R = BigInt(0)
+    tranche.sumFulfilledRedeemOrdersCurrency_R = BigInt(0)
     tranche.tokenPrice = nToBigInt(RAY)
 
     tranche.type = 'ALL'
@@ -158,24 +158,24 @@ export class TrancheService extends Tranche {
   }
 
   public updateOutstandingInvestOrders = (newAmount: bigint, oldAmount: bigint) => {
-    this.sumOutstandingInvestOrders_ = this.sumOutstandingInvestOrders_ + newAmount - oldAmount
+    this.sumOutstandingInvestOrders_R = this.sumOutstandingInvestOrders_R + newAmount - oldAmount
     return this
   }
 
   public updateOutstandingRedeemOrders(newAmount: bigint, oldAmount: bigint, digits: number) {
-    this.sumOutstandingRedeemOrders_ = this.sumOutstandingRedeemOrders_ + newAmount - oldAmount
-    this.sumOutstandingRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.sumOutstandingRedeemOrders_, digits)
+    this.sumOutstandingRedeemOrders_R = this.sumOutstandingRedeemOrders_R + newAmount - oldAmount
+    this.sumOutstandingRedeemOrdersCurrency_R = this.computeCurrencyAmount(this.sumOutstandingRedeemOrders_R, digits)
     return this
   }
 
   public updateFulfilledInvestOrders(amount: bigint) {
-    this.sumFulfilledInvestOrders_ = this.sumFulfilledInvestOrders_ + amount
+    this.sumFulfilledInvestOrders_R = this.sumFulfilledInvestOrders_R + amount
     return this
   }
 
   public updateFulfilledRedeemOrders(amount: bigint, digits: number) {
-    this.sumFulfilledRedeemOrders_ = this.sumFulfilledRedeemOrders_ + amount
-    this.sumFulfilledRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.sumFulfilledRedeemOrders_, digits)
+    this.sumFulfilledRedeemOrders_R = this.sumFulfilledRedeemOrders_R + amount
+    this.sumFulfilledRedeemOrdersCurrency_R = this.computeCurrencyAmount(this.sumFulfilledRedeemOrders_R, digits)
     return this
   }
 

--- a/src/mappings/services/trancheService.ts
+++ b/src/mappings/services/trancheService.ts
@@ -9,14 +9,14 @@ import { TrancheProps } from 'centrifuge-subql/types/models/Tranche'
 export class TrancheService extends Tranche {
   static init(poolId: string, trancheId: string, index: number, trancheData: TrancheDetails) {
     const tranche = new this(`${poolId}-${trancheId}`)
-    tranche.active = true
-    tranche.outstandingInvestOrders_ = BigInt(0)
-    tranche.outstandingRedeemOrders_ = BigInt(0)
-    tranche.outstandingRedeemOrdersCurrency_ = BigInt(0)
-    tranche.fulfilledInvestOrders_ = BigInt(0)
-    tranche.fulfilledRedeemOrders_ = BigInt(0)
-    tranche.fulfilledRedeemOrdersCurrency_ = BigInt(0)
-    tranche.price = nToBigInt(RAY)
+    tranche.isActive = true
+    tranche.sumOutstandingInvestOrders_ = BigInt(0)
+    tranche.sumOutstandingRedeemOrders_ = BigInt(0)
+    tranche.sumOutstandingRedeemOrdersCurrency_ = BigInt(0)
+    tranche.sumFulfilledInvestOrders_ = BigInt(0)
+    tranche.sumFulfilledRedeemOrders_ = BigInt(0)
+    tranche.sumFulfilledRedeemOrdersCurrency_ = BigInt(0)
+    tranche.tokenPrice = nToBigInt(RAY)
 
     tranche.type = 'ALL'
     tranche.poolId = poolId
@@ -24,7 +24,7 @@ export class TrancheService extends Tranche {
     tranche.index = index
     tranche.isResidual = trancheData.trancheType.isResidual
     tranche.seniority = trancheData.seniority.toNumber()
-    tranche.debt = trancheData.debt.toBigInt()
+    tranche.sumDebt = trancheData.debt.toBigInt()
 
     if (!tranche.isResidual) {
       tranche.interestRatePerSec = trancheData.trancheType.asNonResidual.interestRatePerSec.toBigInt()
@@ -57,7 +57,7 @@ export class TrancheService extends Tranche {
 
   static async getActives(poolId: string) {
     const tranches = (await this.getByPoolId(poolId)) as TrancheService[]
-    const activeTranches = tranches.filter((state) => state.active === true)
+    const activeTranches = tranches.filter((state) => state.isActive === true)
     return activeTranches
   }
 
@@ -65,13 +65,13 @@ export class TrancheService extends Tranche {
     const requestPayload = { Tranche: [this.poolId, this.trancheId] }
     const supplyResponse = await api.query.ormlTokens.totalIssuance<u128>(requestPayload)
     logger.info(`SupplyResponse: ${JSON.stringify(supplyResponse)}`)
-    this.supply = supplyResponse.toBigInt()
+    this.tokenSupply = supplyResponse.toBigInt()
     return this
   }
 
   public updatePrice(price: bigint) {
     logger.info(`Updating price for tranche ${this.id} to :${price}`)
-    this.price = price
+    this.tokenPrice = price
     return this
   }
 
@@ -87,7 +87,7 @@ export class TrancheService extends Tranche {
 
   public updateDebt(debt: bigint) {
     logger.info(`Updating debt for tranche ${this.id} to :${debt}`)
-    this.debt = debt
+    this.sumDebt = debt
     return this
   }
 
@@ -113,13 +113,13 @@ export class TrancheService extends Tranche {
         )
         return this
       }
-      if (typeof this.price !== 'bigint') {
+      if (typeof this.tokenPrice !== 'bigint') {
         logger.warn('Price information missing')
         return this
       }
     }
-    const priceCurrent = bnToBn(this.price)
-    const priceOld = referencePeriodStart ? bnToBn(trancheSnapshot.price) : RAY
+    const priceCurrent = bnToBn(this.tokenPrice)
+    const priceOld = referencePeriodStart ? bnToBn(trancheSnapshot.tokenPrice) : RAY
     this[yieldField] = nToBigInt(priceCurrent.mul(RAY).div(priceOld).sub(RAY))
     return this
   }
@@ -144,54 +144,54 @@ export class TrancheService extends Tranche {
       )
       return this
     }
-    if (typeof this.price !== 'bigint') {
+    if (typeof this.tokenPrice !== 'bigint') {
       logger.warn('Price information missing')
       return this
     }
     const annualizationFactor = bnToBn(365 * 24 * 3600 * 1000).div(
       bnToBn(currentPeriodStart.valueOf() - referencePeriodStart.valueOf())
     )
-    const priceCurrent = bnToBn(this.price)
-    const priceOld = bnToBn(trancheSnapshot.price)
+    const priceCurrent = bnToBn(this.tokenPrice)
+    const priceOld = bnToBn(trancheSnapshot.tokenPrice)
     this[yieldField] = nToBigInt(priceCurrent.mul(RAY).div(priceOld).sub(RAY).mul(annualizationFactor))
     return this
   }
 
   public updateOutstandingInvestOrders = (newAmount: bigint, oldAmount: bigint) => {
-    this.outstandingInvestOrders_ = this.outstandingInvestOrders_ + newAmount - oldAmount
+    this.sumOutstandingInvestOrders_ = this.sumOutstandingInvestOrders_ + newAmount - oldAmount
     return this
   }
 
   public updateOutstandingRedeemOrders(newAmount: bigint, oldAmount: bigint, digits: number) {
-    this.outstandingRedeemOrders_ = this.outstandingRedeemOrders_ + newAmount - oldAmount
-    this.outstandingRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.outstandingRedeemOrders_, digits)
+    this.sumOutstandingRedeemOrders_ = this.sumOutstandingRedeemOrders_ + newAmount - oldAmount
+    this.sumOutstandingRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.sumOutstandingRedeemOrders_, digits)
     return this
   }
 
   public updateFulfilledInvestOrders(amount: bigint) {
-    this.fulfilledInvestOrders_ = this.fulfilledInvestOrders_ + amount
+    this.sumFulfilledInvestOrders_ = this.sumFulfilledInvestOrders_ + amount
     return this
   }
 
   public updateFulfilledRedeemOrders(amount: bigint, digits: number) {
-    this.fulfilledRedeemOrders_ = this.fulfilledRedeemOrders_ + amount
-    this.fulfilledRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.fulfilledRedeemOrders_, digits)
+    this.sumFulfilledRedeemOrders_ = this.sumFulfilledRedeemOrders_ + amount
+    this.sumFulfilledRedeemOrdersCurrency_ = this.computeCurrencyAmount(this.sumFulfilledRedeemOrders_, digits)
     return this
   }
 
   private computeCurrencyAmount(amount: bigint, digits: number) {
     return nToBigInt(
       bnToBn(amount)
-        .mul(bnToBn(this.price))
+        .mul(bnToBn(this.tokenPrice))
         .div(CPREC(RAY_DIGITS + WAD_DIGITS - digits))
     )
   }
 
   public deactivate() {
-    this.active = false
+    this.isActive = false
   }
 
   public activate() {
-    this.active = true
+    this.isActive = true
   }
 }


### PR DESCRIPTION
Implements #132 

!!! Breaking Changes !!!
- Period auto-reset variables have suffix `_R`
- Field names updated according to new naming convention
- [Entity]State migrated to [Entity] e.g. `PoolState.abc` is now `Pool.abc`

note: Epoches still have states to track tranche specific information and solutions