### PR TITLE
fix: pool fees rtapi

### DIFF
--- a/src/chaintypes.ts
+++ b/src/chaintypes.ts
@@ -34,13 +34,7 @@ const latestTypes = {
   PoolFeesList: 'Vec<PoolFeesOfBucket>',
   PoolFeesOfBucket: {
     bucket: 'CfgTraitsFeePoolFeeBucket',
-    fees: 'Vec<PoolFee>',
-  },
-  PoolFee: {
-    id: 'u64',
-    destination: 'AccountId32',
-    editor: 'CfgTypesPoolsPoolFeeEditor',
-    amounts: 'CfgTypesPoolsPoolFeeAmounts',
+    fees: 'Vec<CfgTypesPoolsPoolFee>',
   },
 }
 


### PR DESCRIPTION
Should fix decoding error for the `listFees` runtime api. I still don't know why the manual type declaration leads to the decoding error but this worked for me